### PR TITLE
Added private wiki and downgrade rules

### DIFF
--- a/app/controllers/downgrade_controller.rb
+++ b/app/controllers/downgrade_controller.rb
@@ -4,6 +4,7 @@ class DowngradeController < ApplicationController
   
   def create
     current_user.update(role: 0)
+    Wiki.where(user_id: current_user, private: true).update(private: false)
     
     flash[:notice] = "Your account has been downgraded to a standard account. Your private wikis are now public."
     redirect_to root_path

--- a/app/controllers/wikis_controller.rb
+++ b/app/controllers/wikis_controller.rb
@@ -1,6 +1,10 @@
 class WikisController < ApplicationController
   def index
-    @wikis = Wiki.all
+    if current_user.nil? || current_user.role == 'standard'
+      @wikis = Wiki.where(private: false)
+    else
+      @wikis = Wiki.all
+    end
   end
 
   def show
@@ -16,6 +20,8 @@ class WikisController < ApplicationController
     @wiki = Wiki.new
     @wiki.title = params[:wiki][:title]
     @wiki.body = params[:wiki][:body]
+    @wiki.private = params[:wiki][:private]
+    @wiki.user = current_user
     authorize @wiki
     
     if @wiki.save
@@ -36,6 +42,7 @@ class WikisController < ApplicationController
     @wiki = Wiki.find(params[:id])
     @wiki.title = params[:wiki][:title]
     @wiki.body = params[:wiki][:body]
+    @wiki.private = params[:wiki][:private]
     authorize @wiki
     
     if @wiki.save

--- a/app/policies/wiki_policy.rb
+++ b/app/policies/wiki_policy.rb
@@ -1,5 +1,5 @@
 class WikiPolicy < ApplicationPolicy
   def destroy?
-    user.role == 'admin'
+    wiki.user = current_user || user.role == 'admin'
   end
 end

--- a/app/views/wikis/_form.html.erb
+++ b/app/views/wikis/_form.html.erb
@@ -1,0 +1,19 @@
+<%= form_for @wiki do |f| %>
+  <div class="form-group">
+    <%= f.label :title %>
+    <%= f.text_field :title, class: 'form-control', placeholder: "Enter wiki title" %>
+  </div>
+  <div class="form-group">
+    <%= f.label :body %>
+    <%= f.text_area :body, rows: 8, class: 'form-control', placeholder: "Enter wiki information." %>
+  </div>
+  <div class="form-group">
+    <%= f.submit "Save", class: 'btn btn-success' %>
+  
+  <% if current_user.admin? || current_user.premium? %>
+      <%= f.label :private, class: 'checkbox pull-right' do %>
+        <%= f.check_box :private %> Make Wiki Private
+      <% end %>
+  <% end %>
+  </div>
+<% end %>

--- a/app/views/wikis/edit.html.erb
+++ b/app/views/wikis/edit.html.erb
@@ -2,18 +2,6 @@
 
 <div class="row">
   <div class="col-md-8">
-    <%= form_for @wiki do |f| %>
-      <div class="form-group">
-        <%= f.label :title %>
-        <%= f.text_field :title, class: 'form-control', placeholder: "Enter wiki title" %>
-      </div>
-      <div class="form-group">
-        <%= f.label :body %>
-        <%= f.text_area :body, rows: 8, class: 'form-control', placeholder: "Enter wiki information." %>
-      </div>
-      <div class="form-group">
-        <%= f.submit "Save", class: 'btn btn-success' %>
-      </div>
-    <% end %>
+    <%= render 'form', wiki: @wiki %>
   </div>
 </div>

--- a/app/views/wikis/index.html.erb
+++ b/app/views/wikis/index.html.erb
@@ -1,4 +1,5 @@
-<h1>All Wikis</h1>
+<h1>All Wikis <%= link_to "New Wiki", new_wiki_path, class: 'btn btn-success pull-right' %></h1>
+
 <% @wikis.each do |wiki| %>
   <div class="media">
     <div class="media-body">

--- a/app/views/wikis/new.html.erb
+++ b/app/views/wikis/new.html.erb
@@ -2,18 +2,6 @@
 
 <div class="row">
   <div class="col-md-8">
-    <%= form_for @wiki do |f| %>
-      <div class="form-group">
-        <%= f.label :title %>
-        <%= f.text_field :title, class: 'form-control', placeholder: "Enter wiki title" %>
-      </div>
-      <div class="form-group">
-        <%= f.label :body %>
-        <%= f.text_area :body, rows: 8, class: 'form-control', placeholder: "Enter wiki information." %>
-      </div>
-      <div class="form-group">
-        <%= f.submit "Save", class: 'btn btn-success' %>
-      </div>
-    <% end %>
+    <%= render 'form', wiki: @wiki %>
   </div>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,24 +1,55 @@
 require 'random_data'
 
+10.times do
+  User.create!(
+  email:    Faker::Internet.unique.email,
+  password: Faker::Lorem.characters(6..10),
+  role:     'standard',
+  confirmed_at: DateTime.now
+)
+end
+
+admin = User.create!(
+  email:    'admin@example.com',
+  password: 'helloworld',
+  password_confirmation: 'helloworld',
+  role:     'admin',
+  confirmed_at: DateTime.now
+)
+
+premium = User.create!(
+  email:    'member@example.com',
+  password: 'helloworld',
+  password_confirmation: 'helloworld',
+  role:     'premium',
+  confirmed_at: DateTime.now
+)
+  
+standard = User.create!(
+  email:    'user@example.com',
+  password: 'helloworld',
+  password_confirmation: 'helloworld',
+  role:     'standard',
+  confirmed_at: DateTime.now
+)
+users = User.all
+
 50.times do
   Wiki.create!(
+    user:     users.sample,
     title:    Faker::Lorem.sentence,
     body:     Faker::Lorem.paragraph,
     private:  false
   )
 end
 
-admin = User.create!(
-  email:    'admin@example.com',
-  password: 'helloworld',
-  password_confirmation: 'helloworld'
-)
-
-10.times do
-  User.create!(
-  email:    Faker::Internet.unique.email,
-  password: Faker::Lorem.characters(6..10)
-)
+5.times do
+  Wiki.create!(
+    user:     users.sample,
+    title:    Faker::Lorem.sentence,
+    body:     Faker::Lorem.paragraph,
+    private:  true
+  )
 end
 
 puts "Seed finished"


### PR DESCRIPTION
Updated project to use a form partial when rendering `new` and `edit` to account for DRY coding. Added private checkbox and ability for members / admins to use it. Downgrades now make wikis of former members into public wikis.

I still need to update the `show` permissions so that a non-member/admin cannot view private wikis if they type in the private wiki URL manually.